### PR TITLE
Prevent it.only() from appearing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ jobs:
         - pipenv install
         - npm ci
         - npm run build
-      script: npm run test:ci
+      script:
+        - npm run stop-only
+        - npm run test:ci
 
     - stage: deploy
       language: shell

--- a/package-lock.json
+++ b/package-lock.json
@@ -5272,6 +5272,40 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "stop-only": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stop-only/-/stop-only-3.1.0.tgz",
+      "integrity": "sha512-6jh8jRq2eIOQwBG1lQjg+cpxtzl6MuXlapZf82SBlnCN5W+sKO0RfgOp+yIT+qf8zW9mMcGZDpeKVs8wrsBqfw==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.1",
+        "execa": "0.11.0",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.11.0.tgz",
+          "integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "rollup --config --watch & pipenv run dev",
     "build": "rollup -c",
     "test": "pipenv run dev & $(npm bin)/wait-on tcp:127.0.0.1:8000 && $(npm bin)/cypress run",
+    "stop-only": "stop-only --folder cypress/integration",
     "cypress": "npx wait-on tcp:127.0.0.1:8000 && npx cypress run",
     "test:ci": "pipenv run dev & $(npm bin)/wait-on tcp:127.0.0.1:8000 && $(npm bin)/cypress run $CYPRESS_OPTS"
   },
@@ -36,6 +37,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-terser": "^5.3.0",
+    "stop-only": "^3.1.0",
     "wait-on": "^3.3.0"
   },
   "dependencies": {


### PR DESCRIPTION
Using `stop-only`, this fails the CI if it finds `it.only` or `describe.only` in the Cypress tests!