### PR TITLE
add espt coefficient

### DIFF
--- a/src/CreeDictionary/API/search/ranking.py
+++ b/src/CreeDictionary/API/search/ranking.py
@@ -42,7 +42,7 @@ def assign_relevance_score(result: types.Result):
             + 0.0325909057 * len(result.target_language_keyword_match)
             + 0.022778805 * _has_value(result.morpheme_ranking)
             + -0.0009984537 * _default_if_none(result.morpheme_ranking, default=1)
-            + 0.028 * _default_if_none(result.is_espt_result, default=0)
+            + 0.0036 * _default_if_none(result.is_espt_result, default=0)
             + -0.1190890019
             * log(1 + _default_if_none(result.cosine_vector_distance, default=1.1))
         )


### PR DESCRIPTION
## What's in this PR:
I added the coefficient 0.028 to ESPT values in an attempt to push them higher up in the list. I chose this number semi arbitrarily; it falls between the morpheme ranking and the target language keyword match. I figured it was around the same level of importance.

Sometime in the future, we'll want to rebuild the model that generates the coefficients to give ESPT a proper, model-backed value. In order to do this, we need sample data containing translated phrase results so we can learn how valuable this information is.