### PR TITLE
On import, report unknown tags instead of crashing

### DIFF
--- a/src/CreeDictionary/API/search/espt.py
+++ b/src/CreeDictionary/API/search/espt.py
@@ -11,9 +11,9 @@ from CreeDictionary.API.search.espt_crk import (
     crk_noun_tags,
 )
 from CreeDictionary.API.search.types import Result
-from morphodict.analysis.tag_map import UnknownTagError
 from CreeDictionary.phrase_translate.translate import eng_phrase_to_crk_features_fst
-from morphodict.analysis import strict_generator, RichAnalysis
+from morphodict.analysis import RichAnalysis
+from morphodict.analysis.tag_map import UnknownTagError
 from morphodict.lexicon.models import Wordform
 
 logger = logging.getLogger(__name__)

--- a/src/CreeDictionary/phrase_translate/crk_tag_map.py
+++ b/src/CreeDictionary/phrase_translate/crk_tag_map.py
@@ -13,8 +13,6 @@ noun_wordform_to_phrase = TagMap(
     ("+Obv", COPY_TAG_NAME, 1),
     ("+Loc", COPY_TAG_NAME, 1),
     ("+Distr", COPY_TAG_NAME, 1),
-    ## XXX FIXME I have no idea what +Voc is but it causes problems so drop it
-    ("+Voc", None, 0),
     # Diminutive
     ("+Dim", COPY_TAG_NAME, 2),
     ("+Der/Dim", "Dim+", 2),


### PR DESCRIPTION
Sample output:

    unknown_tags_during_auto_translation: 4x RdplW+