### PR TITLE
Fixed (re-)coding of inclusive first person plural tags from English FST a…

### DIFF
--- a/src/CreeDictionary/API/search/espt_crk.py
+++ b/src/CreeDictionary/API/search/espt_crk.py
@@ -28,7 +28,7 @@ noun_passthrough_tags = {
         "+Px3Sg",
         "+Px1Pl",
         "+Px2Pl",
-        "+Px12Pl",
+        # "+Px12Pl", # Needs to be recoded: 21 -> 12
         "+Px3Pl",
         "+Px4Sg/Pl",
         "+PxX",
@@ -58,7 +58,7 @@ verb_passthrough_tags = {
         "+2Sg",
         "+3Sg",
         "+1Pl",
-        "+12Pl",
+        # "+12Pl", # Needs to be recoded: 21 -> 12
         "+2Pl",
         "+3Pl",
         "+4Sg/Pl",
@@ -71,7 +71,7 @@ verb_passthrough_tags = {
         "+2SgO",
         "+3SgO",
         "+1PlO",
-        "+21PlO",
+        # "+21PlO", # Needs to be recoded: 21 -> 12
         "+2PlO",
         "+3PlO",
         "+4Pl",
@@ -105,12 +105,16 @@ verb_tag_map = TagMap(
     (TagMap.DEFAULT, "+Ind", 1),
     # Person - see https://github.com/UAlbertaALTLab/morphodict/issues/891
     ("+0Sg", "+3Sg", 2),
+    ("+21Pl", "+12Pl", 2), # see https://github.com/UAlbertaALTLab/morphodict/issues/1005
     # Person - object
     ("+0SgO", (), 3),
+    ("+21PlO", "+12PlO", 3), # see https://github.com/UAlbertaALTLab/morphodict/issues/1005
     # TODO: also handle "+Inf": ("PV/ta+", "+Cnj")  # future definite?
     *passthrough_tags_to_tuples(verb_passthrough_tags)
 )
 
 noun_tag_map = TagMap(
-    ("+Dim", "+Der/Dim", 2), *passthrough_tags_to_tuples(noun_passthrough_tags)
+    ("+Dim", "+Der/Dim", 2),
+    ("+Px21Pl","+Px12Pl",2),
+    *passthrough_tags_to_tuples(noun_passthrough_tags)
 )

--- a/src/CreeDictionary/phrase_translate/crk_tag_map.py
+++ b/src/CreeDictionary/phrase_translate/crk_tag_map.py
@@ -22,7 +22,7 @@ noun_wordform_to_phrase = TagMap(
     ("+Px3Sg", COPY_TAG_NAME, 3),
     ("+Px1Pl", COPY_TAG_NAME, 3),
     ("+Px2Pl", COPY_TAG_NAME, 3),
-    ("+Px12Pl", COPY_TAG_NAME, 3),
+    ("+Px12Pl", COPY_TAG_NAME, 3), # Maybe needs to be recoded with 12 -> 21
     ("+Px3Pl", COPY_TAG_NAME, 3),
     ("+Px4Sg/Pl", COPY_TAG_NAME, 3),
     ("+PxX", COPY_TAG_NAME, 3),


### PR DESCRIPTION
Recode English FST analysis for inclusive first person plural with `21` to crk FST format with `12` (for actor: `+21Pl` -> `+12Pl`, goal: `+21PlO` -> `+12PlO`, and possessor: `+Px21Pl` -> `+Pxl12Pl`).

Based on local version seems to work, but one yet needs to check whether one more change is needed concerning the possessor tags in [crk_tag_map.py](https://github.com/UAlbertaALTLab/morphodict/blob/main/src/CreeDictionary/phrase_translate/crk_tag_map.py).

This addresses issues #1005 (point 3), #1006 (question 2), and this earlier comment https://github.com/UAlbertaALTLab/morphodict/issues/875#issuecomment-888722609.