### PR TITLE
change: speakers link goes to speech-db

### DIFF
--- a/src/crkeng/app/templates/CreeDictionary/index.html
+++ b/src/crkeng/app/templates/CreeDictionary/index.html
@@ -35,7 +35,7 @@
 
   <p>
     The spoken Cree word recordings are courtesy of
-      <a href="https://www.altlab.dev/maskwacis/Speakers/speakers.html">speakers in Maskwacîs</a>. 
+      <a href="https://speech-db.altlab.app/maskwacis/speakers/">speakers in Maskwacîs</a>.
   </p>
 </article>
 {% endblock %}


### PR DESCRIPTION
The speakers link now points to the speech-db speakers page, which features the recorded and written bios.