### PR TITLE
Fix cvd:2, and tests breaking definition vectors

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 🖥 Install system dependencies
       run: sudo apt-get install -y libfoma0
     - name: ☤ Install pipenv
-      run: python3 -m pip install pipenv
+      run: python3 -m pip install pipenv==2021.5.29
 
     # This started out life as a copy-paste from
     # https://github.com/actions/cache/blob/main/examples.md#python---pipenv
@@ -110,7 +110,7 @@ jobs:
     - name: 🖥 Install system dependencies
       run: sudo apt-get install -y libfoma0 libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     - name: ☤ Install pipenv
-      run: python3 -m pip install pipenv
+      run: python3 -m pip install pipenv==2021.5.29
 
     # This started out life as a copy-paste from
     # https://github.com/actions/cache/blob/main/examples.md#python---pipenv

--- a/src/CreeDictionary/API/search/core.py
+++ b/src/CreeDictionary/API/search/core.py
@@ -1,12 +1,13 @@
-from typing import Any, Iterable
+from typing import Iterable, Callable, Any, Optional
 
 from django.db.models import prefetch_related_objects
 
 from crkeng.app.preferences import DisplayMode, AnimateEmoji
+from morphodict.lexicon.models import WordformKey
 from . import types, presentation
 from .query import Query
+from .types import Result
 from .util import first_non_none_value
-from morphodict.lexicon.models import Wordform, wordform_cache, WordformKey
 
 
 class SearchRun:
@@ -30,6 +31,8 @@ class SearchRun:
     _results: dict[WordformKey, types.Result]
     VerboseMessage = dict[str, str]
     _verbose_messages: list[VerboseMessage]
+    # Set this to use a custom sort function
+    sort_function: Optional[Callable[[Result], Any]] = None
 
     def add_result(self, result: types.Result):
         if not isinstance(result, types.Result):
@@ -53,7 +56,11 @@ class SearchRun:
         results = list(self._results.values())
         for r in results:
             r.assign_default_relevance_score()
-        results.sort()
+
+        if self.sort_function is not None:
+            results.sort(key=self.sort_function)
+        else:
+            results.sort()
         return results
 
     def presentation_results(

--- a/src/CreeDictionary/API/search/runner.py
+++ b/src/CreeDictionary/API/search/runner.py
@@ -12,6 +12,7 @@ from CreeDictionary.API.search.cvd_search import do_cvd_search
 from CreeDictionary.API.search.espt import EsptSearch
 from CreeDictionary.API.search.lookup import fetch_results
 from CreeDictionary.API.search.query import CvdSearchType
+from CreeDictionary.API.search.types import Result
 from CreeDictionary.API.search.util import first_non_none_value
 from CreeDictionary.utils.types import cast_away_optional
 
@@ -42,6 +43,11 @@ def search(
 
         # For when you type 'cvd:exclusive' in a query to debug ONLY CVD results!
         if cvd_search_type == CvdSearchType.EXCLUSIVE:
+
+            def sort_by_cvd(r: Result):
+                return r.cosine_vector_distance
+
+            search_run.sort_function = sort_by_cvd
             do_cvd_search(search_run)
             return search_run
 

--- a/src/morphodict/lexicon/importer/test_importer.py
+++ b/src/morphodict/lexicon/importer/test_importer.py
@@ -26,7 +26,10 @@ def import_test_file(filename, reimport=False, **command_kwargs):
 
     def do_import():
         call_command(
-            "importjsondict", json_file=TESTDATA_DIR / filename, **command_kwargs
+            "importjsondict",
+            skip_building_vectors_because_testing=True,
+            json_file=TESTDATA_DIR / filename,
+            **command_kwargs,
         )
 
     do_import()


### PR DESCRIPTION
`cvd:2` aka `cvd:exclusive` is documented as using cvd exclusively for
both retrieval and ranking, but in practice it actually used the
weighted relevance function for ranking. This PR makes it sort results
strictly by cvd.

Additionally, the import tests I added in late September were
inadvertently overwriting the test db definition vector files with tiny
ones only containing a handful of vectors. This PR fixes that.

Also: the recent errors running tests on GitHub, with `django` not
being found? That’s just wild and makes no sense. pipenv did just
release a new version so I’ll assume it’s a bug in that; downgrading
to the previous release seems to have worked for me.