### PR TITLE
fix: default to basic if it exists

### DIFF
--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -59,7 +59,10 @@ def entry_details(request, slug: str):
     if paradigm is not None:
         paradigm_manager = default_paradigm_manager()
         sizes = list(paradigm_manager.sizes_of(paradigm))
-        default_size = sizes[0]
+        if "basic" in sizes:
+            default_size = "basic"
+        else:
+            default_size = sizes[0]
 
         if len(sizes) <= 1:
             size = default_size


### PR DESCRIPTION
## What's in this PR:
The default paradigm size was being determined based solely on its position in the list of all sizes available. In production, "full" appeared before "basic" in the list of sizes, so it was always defaulting to "full". This PR fixes that issue.

**Notes:**
I tried to undo my rogue push to main but it didn't seem to take.