### PR TITLE
Update reformat.yml with the latest git-auto-commit

### DIFF
--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Reformat
       run: ./scripts/reformat-altlabels
     - name: Git Auto Commit
-      uses: stefanzweifel/git-auto-commit-action@v4.3.0
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "🤖🧹 reformat crk.altlabel [skip ci]"
+        commit_message: "🤖🧹 reformat crk.altlabel"
 
   reformat-python:
     runs-on: ubuntu-latest
@@ -48,9 +48,9 @@ jobs:
       run: |
         black .
     - name: Git Auto Commit
-      uses: stefanzweifel/git-auto-commit-action@v4.3.0
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "🤖🧹 reformat Python files [skip ci]"
+        commit_message: "🤖🧹 reformat Python files"
 
   reformat-javascript:
     runs-on: ubuntu-latest
@@ -70,9 +70,9 @@ jobs:
     - name: Reformat JavaScript
       run: npm run reformat
     - name: Git Auto Commit
-      uses: stefanzweifel/git-auto-commit-action@v4.3.0
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "🤖🧹 reformat JavaScript files [skip ci]"
+        commit_message: "🤖🧹 reformat JavaScript files"
 
   reformat-importjson:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip reformat]')"
@@ -114,6 +114,6 @@ jobs:
       run: "pipenv run ./crkeng-manage sortimportjson --git-files"
 
     - name: Git Auto Commit
-      uses: stefanzweifel/git-auto-commit-action@v4.3.0
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "🤖🧹 reformat importjson files [skip ci]"
+        commit_message: "🤖🧹 reformat importjson files"


### PR DESCRIPTION
TIL: github actions are not matched semantically (though they encourage semantic versioning of actions)

[see discussion here](https://github.community/t/version-numbering-for-actions/16307)

They match by tags/releases, that's why the [git-auto-commit has tags like v4 v4.12.0 latest...etc](https://github.com/stefanzweifel/git-auto-commit-action)

The readme of git auto commit seem to suggest people to use `v4`. Anyhow, git auto commit has released `v4.12.0`, yet the workflow still uses the fixed `v4.3.0`. Should be wrong to bump the minor version.

[Also `[skip ci]` is unnecessary here](https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs)