### PR TITLE
change: uncomment line of code to include preverbs in espt

### DIFF
--- a/src/CreeDictionary/phrase_translate/translate.py
+++ b/src/CreeDictionary/phrase_translate/translate.py
@@ -38,7 +38,7 @@ if package_dir not in sys.path:
 
 from CreeDictionary.phrase_translate.crk_tag_map import (
     noun_wordform_to_phrase,
-    verb_wordform_to_phrase,
+    verb_wordform_to_phrase, permitted_preverb_tags,
 )
 
 from CreeDictionary.utils.shared_res_dir import shared_fst_dir
@@ -190,7 +190,7 @@ def translate_single_definition(wordform, text, stats: TranslationStats):
         ## switch to computing them on-demand instead of pre-computing them all
         ## in advance?
         #
-        # and t not in permitted_preverb_tags
+        and t not in permitted_preverb_tags
         for t in wordform.analysis.prefix_tags
     ):
         logger.debug(


### PR DESCRIPTION
I uncommented a line of code to include preverbs in the translation process again.

@aarppe from what I can tell, this makes the search functionality a lot slower, not the import process like I thought.

The query `you will dance espt:1 auto:1 verbose:1` takes about 13 seconds to return results with this change, whereas it only takes about 1-2 seconds on production right now. The results, as far as I can tell, are the exact same.

Feel free to pull this branch and look at it locally, but I'm not sure if this change is worth it at this time.