### PR TITLE
Fix/cr on search

### DIFF
--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -217,24 +217,28 @@ class PresentationResult:
 
 
 def should_show_form_of(is_lemma, lemma_wordform, dict_source, include_auto_definitions):
-    if dict_source:
-        if not is_lemma:
-            if lemma_wordform.definitions.exists():
-                for definition in lemma_wordform.definitions.all():
-                    print(definition.source_ids)
-                    for source in definition.source_ids:
-                        if source in dict_source:
-                            return True
-                        elif (
-                                include_auto_definitions
-                                and source.replace("🤖", "") in dict_source
-                        ):
-                            return True
-            return True
-        else:
-            return True
-    else:
+    print(is_lemma)
+    print(lemma_wordform)
+    print(dict_source)
+    print(include_auto_definitions)
+    if not dict_source:
         return True
+    for definition in lemma_wordform.definitions.all():
+        print(definition)
+        for source in definition.source_ids:
+            print("source:", source)
+            if source in dict_source:
+                print("231")
+                return True
+            elif (
+                    include_auto_definitions
+                    and source.replace("🤖", "") in dict_source
+            ):
+                print("237")
+                return True
+        print("239")
+        return False
+
 
 def serialize_wordform(
     wordform: Wordform, animate_emoji: str, dict_source: list

--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -180,7 +180,7 @@ class PresentationResult:
             "friendly_linguistic_breakdown_head": self.friendly_linguistic_breakdown_head,
             "friendly_linguistic_breakdown_tail": self.friendly_linguistic_breakdown_tail,
             "relabelled_fst_analysis": self.relabelled_fst_analysis,
-            "show_form_of": should_show_form_of(self.is_lemma, self.wordform, self.dict_source, self._search_run.include_auto_definitions),
+            "show_form_of": should_show_form_of(self.is_lemma, self.lemma_wordform, self.dict_source, self._search_run.include_auto_definitions),
         }
         if self._search_run.query.verbose:
             cast(Any, ret)["verbose_info"] = self._result
@@ -217,26 +217,17 @@ class PresentationResult:
 
 
 def should_show_form_of(is_lemma, lemma_wordform, dict_source, include_auto_definitions):
-    print(is_lemma)
-    print(lemma_wordform)
-    print(dict_source)
-    print(include_auto_definitions)
     if not dict_source:
         return True
     for definition in lemma_wordform.definitions.all():
-        print(definition)
         for source in definition.source_ids:
-            print("source:", source)
             if source in dict_source:
-                print("231")
                 return True
             elif (
                     include_auto_definitions
                     and source.replace("🤖", "") in dict_source
             ):
-                print("237")
                 return True
-        print("239")
         return False
 
 

--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -219,16 +219,20 @@ class PresentationResult:
 def should_show_form_of(is_lemma, lemma_wordform, dict_source, include_auto_definitions):
     if dict_source:
         if not is_lemma:
-            for definition in lemma_wordform["definitions"]:
-                for source in definition["source_ids"]:
-                    if source in dict_source:
-                        return True
-                    elif (
-                            include_auto_definitions
-                            and source.replace("🤖", "") in dict_source
-                    ):
-                        return True
-        return False
+            if lemma_wordform.definitions.exists():
+                for definition in lemma_wordform.definitions.all():
+                    print(definition.source_ids)
+                    for source in definition.source_ids:
+                        if source in dict_source:
+                            return True
+                        elif (
+                                include_auto_definitions
+                                and source.replace("🤖", "") in dict_source
+                        ):
+                            return True
+            return True
+        else:
+            return True
     else:
         return True
 

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -126,10 +126,6 @@ def index(request):  # pragma: no cover
         )
         did_search = True
 
-        search_results = should_show_form_of(
-            search_results, dict_source, include_auto_definitions
-        )
-
     else:
         search_results = []
         did_search = False
@@ -446,24 +442,3 @@ def divide_chunks(terms, size):
     # looping till length l
     for i in range(0, len(terms), size):
         yield terms[i : i + size]
-
-
-def should_show_form_of(search_results, dict_source, include_auto_definitions):
-    for r in search_results:
-        if dict_source:
-            if not r["is_lemma"]:
-                for d in r["lemma_wordform"]["definitions"]:
-                    for s in d["source_ids"]:
-                        if s in dict_source:
-                            r["show_form_of"] = True
-                        elif (
-                            include_auto_definitions
-                            and s.replace("🤖", "") in dict_source
-                        ):
-                            r["show_form_of"] = True
-            if "show_form_of" not in r:
-                r["show_form_of"] = False
-        else:
-            r["show_form_of"] = True
-
-    return search_results


### PR DESCRIPTION
## What's in this PR:
Solves #1046 
You no longer need to press Return to see search results with a dictionary source selected.

This entailed moving a piece of the logic to an earlier place in the search process.