### PR TITLE
Paradigm audio option

### DIFF
--- a/cypress/integration/crkeng/paradigm.spec.js
+++ b/cypress/integration/crkeng/paradigm.spec.js
@@ -135,7 +135,6 @@ describe("paradigms can be toggled by the show more/less button", () => {
 
     // Switch to the full size
     cy.get("[data-cy=paradigm-toggle-button]").click();
-    cy.wait(5000);    // needs time to load paradigm audio
     cy.location("search").should("match", /\bfull\b/i);
 
     paradigm().contains("td", basicForm);
@@ -143,7 +142,6 @@ describe("paradigms can be toggled by the show more/less button", () => {
 
     // Switch once more to get back to the basic paradigm
     cy.get("[data-cy=paradigm-toggle-button]").click();
-    cy.wait(5000);    // needs time to load paradigm audio
     cy.location("search").should("match", /\bbasic\b/i);
 
     function paradigm() {

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -392,7 +392,7 @@ def paradigm_for(wordform: Wordform, paradigm_size: str) -> Optional[Paradigm]:
 
 
 def get_recordings_from_paradigm(paradigm, request):
-    if request.COOKIES.get("paradigm_audio") == "no":
+    if request.COOKIES.get("paradigm_audio") in ["no", None] :
         return paradigm
 
     query_terms = []


### PR DESCRIPTION
## What's in this PR:
Fixes to the initial implementation of selecting whether or not you'd like to see audio in the paradigms. If the cookie wasn't set, it would return the audio. I made it so that no selection implies the user doesn't want to see paradigm audio.