### PR TITLE
fix: relabelling for info table

### DIFF
--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -239,17 +239,15 @@ class PresentationResult:
             info = re.findall(pattern, analysis)
             cleaned_info = []
             for i in info:
-                print(i)
                 if "<b>" in i:
                     j = i.replace("<b>", "").replace("</b>", "")
                 else:
                     j = i
                 cleaned_info.append(j)
-            print(cleaned_info)
             relabelled = []
             for c in cleaned_info:
-                if self._relabeller.get_longest(c):
-                    relabelled.append(self._relabeller.get_longest(c))
+                if self._relabeller.get(c):
+                    relabelled.append(self._relabeller.get(c))
                 else:
                     relabelled.append(c)
 


### PR DESCRIPTION
Relabelling for the info table seems to be working now. Here are the three different modes:

Linguist:
<img width="683" alt="Screen Shot 2022-03-30 at 10 45 55 AM" src="https://user-images.githubusercontent.com/28357720/160888462-6df16b7b-2f02-4b52-80be-20ee216a4882.png">

English:
<img width="557" alt="Screen Shot 2022-03-30 at 10 46 06 AM" src="https://user-images.githubusercontent.com/28357720/160888484-06bfed04-5836-4dd2-b335-4123a9b7761f.png">

Tsuut'ina:
<img width="562" alt="Screen Shot 2022-03-30 at 10 46 21 AM" src="https://user-images.githubusercontent.com/28357720/160888527-f3ee48d8-5eee-4c55-b396-84212da6392b.png">


@aarppe Does this look correct now?
