### PR TITLE
move: lexical table to dict icon; dict icon to file

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__elaboration.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__elaboration.html
@@ -49,14 +49,7 @@
                     <div class="tooltip__arrow" data-popper-arrow></div>
                 </div>
 
-                {% if result.lemma_wordform.stem %}
-                    <span data-has-tooltip aria-describedby="tooltip:linguistic-{{ id }}"><div data-cy="linguistic-dict-icon"> &nbsp; 📖 </div></span>
-                    <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
-                        <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
-
-                        <div class="tooltip__arrow" data-popper-arrow></div>
-                    </div>
-                {% endif %}
+                {% include "CreeDictionary/components/lexical-breakdown.html" %}
             {% endif %}
 
             {% if display_options.mode == 'english' %}
@@ -73,14 +66,7 @@
                     <div class="tooltip__arrow" data-popper-arrow></div>
                 </div>
 
-                {% if result.lemma_wordform.stem %}
-                    <span data-has-tooltip aria-describedby="tooltip:linguistic-{{ id }}"> &nbsp;  📖 </span>
-                    <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
-                        <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
-
-                        <div class="tooltip__arrow" data-popper-arrow></div>
-                    </div>
-                {% endif %}
+                {% include "CreeDictionary/components/lexical-breakdown.html" %}
             {% endif %}
 
             {% if display_options.mode == 'source_language' %}
@@ -97,14 +83,7 @@
                     <div class="tooltip__arrow" data-popper-arrow></div>
                 </div>
 
-                {% if result.lemma_wordform.stem %}
-                    <span data-has-tooltip aria-describedby="tooltip:linguistic-{{ id }}"> &nbsp;  📖 </span>
-                    <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
-                        <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
-
-                        <div class="tooltip__arrow" data-popper-arrow></div>
-                    </div>
-                {% endif %}
+                {% include "CreeDictionary/components/lexical-breakdown.html" %}
             {% endif %}
         {% endwith %}
     </div>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/lexical-breakdown.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/lexical-breakdown.html
@@ -1,0 +1,13 @@
+{% if result.lemma_wordform.stem or result.relabelled_linguist_analysis %}
+    <span data-has-tooltip aria-describedby="tooltip:linguistic-{{ id }}"
+          data-cy="linguistic-dict-icon">&nbsp; 📖 </span>
+    <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
+        {% if result.relabelled_linguist_analysis %}
+            {{ result.relabelled_linguist_analysis  | safe }}
+        {% else %}
+            <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
+        {% endif %}
+
+        <div class="tooltip__arrow" data-popper-arrow></div>
+    </div>
+{% endif %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -31,18 +31,13 @@
 
         <div class="tooltip" role="tooltip">
             <div data-cy="linguistic-breakdown">
-                {% if result.relabelled_linguist_analysis %}
-                    {{ result.relabelled_linguist_analysis  | safe }}
-                {% else %}
-
-                    <ol class="linguistic-breakdown__list">
-                        {% for chunk in result.relabelled_fst_analysis %}
-                            <li>
-                                <data value="{{ chunk.tags }}"> {{ chunk.label }}</data>
-                            </li>
-                        {% endfor %}
-                    </ol>
-                {% endif %}
+                <ol class="linguistic-breakdown__list">
+                    {% for chunk in result.relabelled_fst_analysis %}
+                        <li>
+                            <data value="{{ chunk.tags }}"> {{ chunk.label }}</data>
+                        </li>
+                    {% endfor %}
+                </ol>
             </div>
 
             <div class="tooltip__arrow" data-popper-arrow></div>


### PR DESCRIPTION
## What's in this PR:
* move the lexical info popup into its own component/file
* moved the lexical table to the lexical info popup:

<img width="410" alt="Screen Shot 2022-03-30 at 2 26 48 PM" src="https://user-images.githubusercontent.com/28357720/160924871-15f1d348-cb00-474e-9acd-ba3c1a67d0cc.png">
 

@aarppe This should now be the expected behaviour, coming out of the dictionary/book icon