### PR TITLE
change: compare morph breakdown to inflection

### DIFF
--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -156,7 +156,7 @@ class PresentationResult:
         )
 
         if rich_analysis := result.wordform.analysis:
-            self.morphemes = rich_analysis.generate_with_morphemes()
+            self.morphemes = rich_analysis.generate_with_morphemes(result.wordform.text)
         else:
             self.morphemes = None
 
@@ -342,7 +342,6 @@ def serialize_wordform(
                 wordclass, animate_emoji
             )
     result["show_emoji"] = True if show_emoji == "yes" else False
-    print(result["show_emoji"])
 
     for key in wordform.linguist_info or []:
         if key not in result:

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -535,7 +535,7 @@ class WordformCell(Cell):
         analysis = rich_analyze_strict(self.inflection)
         if analysis:
             analysis = analysis[0]
-            self.morphemes = analysis.generate_with_morphemes()
+            self.morphemes = analysis.generate_with_morphemes(self.inflection)
 
     def fill(self, forms: Mapping[str, Collection[str]]) -> tuple[Cell, ...]:
         # No need to fill a cell that already has contents!

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -57,7 +57,7 @@ def entry_details(request, slug: str):
     lemma = lemma.get()
 
     if rich_analysis := lemma.analysis:
-        morphemes = rich_analysis.generate_with_morphemes()
+        morphemes = rich_analysis.generate_with_morphemes(lemma.text)
     else:
         morphemes = None
 

--- a/src/morphodict/analysis/__init__.py
+++ b/src/morphodict/analysis/__init__.py
@@ -80,10 +80,13 @@ class RichAnalysis:
     def generate(self):
         return strict_generator().lookup(self.smushed())
 
-    def generate_with_morphemes(self):
+    def generate_with_morphemes(self, inflection):
         try:
             results = strict_generator_with_morpheme_boundaries().lookup(self.smushed())
             if len(results) != 1:
+                for result in results:
+                    if ''.join(re.split(r"[<>]", result)) == inflection:
+                        return re.split(r"[<>]", result)
                 return None
             return re.split(r"[<>]", results[0])
         except RuntimeError as e:


### PR DESCRIPTION
Resolves #1071 

Morpheme breakdowns are compared to inflected wordforms so we can know which breakdown to return.