### PR TITLE
fix: unindent

### DIFF
--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -300,13 +300,15 @@ def should_show_form_of(
 ):
     if not dict_source:
         return True
+    if is_lemma:
+        return True
     for definition in lemma_wordform.definitions.all():
         for source in definition.source_ids:
             if source in dict_source:
                 return True
             elif include_auto_definitions and source.replace("🤖", "") in dict_source:
                 return True
-        return False
+    return False
 
 
 def serialize_wordform(


### PR DESCRIPTION
Resolves #1046 

The code was only iterating over one definition before making its decision, now it looks at all definitions before deciding if it should show the "form of" section for a particular entry.