### PR TITLE
feat: show inflectional category with entries

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__elaboration.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__elaboration.html
@@ -35,6 +35,9 @@
     <div class="definition__elaboration" data-cy="elaboration">
 
         {% with ic=lemma.inflectional_category_plain_english emoji=lemma.wordclass_emoji id=request|unique_id %}
+            {% if show_ic != "no" %}
+                {{ lemma.inflectional_category }}
+            {% endif %}
             {% if display_options.mode == 'linguistic' %}
                 {% if lemma.show_emoji %}
                     <span class="wordclass" data-cy="word-class">

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -72,6 +72,35 @@
             </form>
         </section>
 
+    <section>
+            <h3 id="show-inflectional-category" class="setting__title">Inflectional Category</h3>
+
+            <p class="setting__note"> Would you like to see the inflectional category with search results?</p>
+
+            <form method="POST" action="{% url "preference:change" "show_inflectional_category" %}"
+                  data-save-preference="show_inflectional_category">
+                <ul class="unbullet">
+                    {% for value, label in preferences.show_inflectional_category.choices_with_labels %}
+                        <li class="option">
+                            <label class="option__label">
+                                <input type="radio" name="show_inflectional_category" value="{{ value }}" class="option__control"
+                                       {% if preferences.show_inflectional_category.current_choice == value %}checked{% endif %}>
+                                <span class="option__label-text">{{ value|capfirst }}</span>
+                            </label>
+                            <p class="option__description">
+                                {{ label }}
+                            </p>
+                        </li>
+                    {% endfor %}
+                </ul>
+
+                <div class="action-bar">
+                    {% csrf_token %}
+                    <button type="submit"> Save settings</button>
+                </div>
+            </form>
+        </section>
+
         <section>
             <h3 id="show-emoji" class="setting__title">Show emojis with entries?</h3>
 

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -187,6 +187,7 @@ def search_results(request, query_string: str):  # pragma: no cover
             "query_string": query_string,
             "search_results": results,
             "show_morphemes": request.COOKIES.get("show_morphemes"),
+            "show_ic": request.COOKIES.get("show_inflectional_category"),
         },
     )
 

--- a/src/crkeng/app/preferences.py
+++ b/src/crkeng/app/preferences.py
@@ -142,3 +142,17 @@ class SynthesizedAudioInParadigm(Preference):
         "no": "I do not want to hear synthesized recordings in my paradigm layouts",
     }
     default = "no"
+
+
+@register_preference
+class ShowInflectionalCategory(Preference):
+    """
+    Should we show synthesized audio in the paradigms?
+    """
+
+    cookie_name = "show_inflectional_category"
+    choices = {
+        "yes": "I always want to see the inflectional category",
+        "no": "I only want to see the inflectional category in linguistic mode",
+    }
+    default = "yes"


### PR DESCRIPTION
## What's in this PR:
Unless otherwise specified, the inflectional category will be displayed alongside an entry, like so:
![Screen Shot 2022-05-24 at 12 27 48 PM](https://user-images.githubusercontent.com/28357720/170106499-79304c56-da7d-4a22-9ccf-e6ad83541b20.png)


**NOTE:** I named this branch the wrong thing, it should be `ic` not `pos`