### PR TITLE
change: verbose shows all features used in weighting always

### DIFF
--- a/src/CreeDictionary/API/search/types.py
+++ b/src/CreeDictionary/API/search/types.py
@@ -226,10 +226,9 @@ class Result:
     def features(self):
         ret = {}
         for field in dataclasses.fields(Result):
-            if field.name not in ["wordform", "lemma_wordform"]:
+            if field.name in ["target_language_keyword_match", "morpheme_ranking", "glossary_count", "lemma_freq", "pos_match", "cosine_vector_distance"]:
                 value = getattr(self, field.name)
-                if value is not None:
-                    ret[field.name] = value
+                ret[field.name] = value
         return ret
 
     def features_json(self):


### PR DESCRIPTION
## What's in this PR:
When using `verbose:1` in a search, the resulting JSON will always show the values for all the features used in search weighting, regardless of if they have a value or not.