### PR TITLE
add: filter to sort definition sources

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/citations.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/citations.html
@@ -22,7 +22,7 @@
 
   {% load creedictionary_extras %}
 
-  {% for source in dictionary_sources %}
+  {% for source in dictionary_sources|sort_sources %}
     {% with id=request|unique_id %}
       <cite class="cite-dict" data-has-tooltip aria-describedby="tooltip:{{ id }}">{{ source }} </cite>
 

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/lexical-info.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/lexical-info.html
@@ -44,7 +44,7 @@
                 <p class="preverb-breakdown__preverb-definition">
                     <span class="preverb-breakdown__preverb-definition-text">{{ definition.text }}</span>
             {% if item.entry.id %} {# we know the preverb in the database #}
-                {% for source in definition.source_ids %}
+                {% for source in definition.source_ids|sort_sources %}
                     <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
                 {% endfor %}
             {% endif %}

--- a/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -175,3 +175,18 @@ def relabel_linguistic_long(pos: str):
     transitive animate verb – class 1: regular
     """
     return read_labels().linguistic_long.get(pos)
+
+
+@register.filter()
+def sort_sources(sources: list):
+    """
+    Should take in a class and return the plain english labelling for it
+    So if I pass in "VTA-1", I should get back:
+    transitive animate verb – class 1: regular
+    """
+    if "CW" in sources:
+        sources.remove("CW")
+        ret = ["CW"] + sources[:]
+    else:
+        ret = sources
+    return ret


### PR DESCRIPTION
This makes it so CW comes before any other sources in the citations.