### PR TITLE
remove: remove-orphans while deploying .dev sites

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -20,12 +20,12 @@ SYSTEMD_SERVICE = docker-compose-itwewina
 
 .PHONY: production
 production: db.sqlite3 .env
-	docker-compose up --build --remove-orphans
+	docker-compose up --build
 
 .PHONY: staging
 staging: .env ../src/CreeDictionary/test_db.sqlite3
 	ln -f ../src/CreeDictionary/test_db.sqlite3 ./db.sqlite3
-	docker-compose up --build --remove-orphans
+	docker-compose up --build
 
 .PHONY: unit-file
 unit-file: $(SYSTEMD_SERVICE).service

--- a/docker/inner_deploy.py
+++ b/docker/inner_deploy.py
@@ -3,5 +3,5 @@ def run(call):
 
     call(["./helper.py", "setup"])
     call(["docker-compose", "pull"])
-    call(["docker-compose", "up", "-d", "--remove-orphans"])
+    call(["docker-compose", "up", "-d"])
     call(["./helper.py", "manage", "all", "migrate"])


### PR DESCRIPTION
I can't seem to deploy the dev sites without taking down production. I'm hoping this small changes lets me run everything at the same time.