### PR TITLE
srs audio

### DIFF
--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -26,7 +26,7 @@ from crkeng.app.preferences import DisplayMode, AnimateEmoji, ShowEmoji
 from morphodict.lexicon.models import Wordform
 
 from .paradigm.manager import ParadigmDoesNotExistError
-from .paradigm.panes import Paradigm
+from .paradigm.panes import Paradigm, WordformCell
 from .utils import url_for_query
 
 # The index template expects to be rendered in the following "modes";
@@ -456,8 +456,8 @@ def get_recordings_from_paradigm(paradigm, request):
         for row in pane.tr_rows:
             if not row.is_header:
                 for cell in row.cells:
-                    if cell.is_inflection:
-                        if str(cell) in matched_recordings:
+                    if cell.is_inflection and isinstance(cell, WordformCell):
+                        if cell.inflection in matched_recordings.keys():
                             cell.add_recording(matched_recordings[str(cell)])
 
     return paradigm

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -450,7 +450,7 @@ def get_recordings_from_paradigm(paradigm, request):
     for search_terms in divide_chunks(query_terms, 30):
         for source in speech_db_eq:
             url = f"https://speech-db.altlab.app/{source}/api/bulk_search"
-            matched_recordings.update(get_recordings_from_url(search_terms, url))
+            matched_recordings.update(get_recordings_from_url(search_terms, url, speech_db_eq))
 
     for pane in paradigm.panes:
         for row in pane.tr_rows:
@@ -463,14 +463,17 @@ def get_recordings_from_paradigm(paradigm, request):
     return paradigm
 
 
-def get_recordings_from_url(search_terms, url):
+def get_recordings_from_url(search_terms, url, speech_db_eq):
     matched_recordings = {}
     query_params = [("q", term) for term in search_terms]
     response = requests.get(url + "?" + urllib.parse.urlencode(query_params))
     recordings = response.json()
 
     for recording in recordings["matched_recordings"]:
-        entry = macron_to_circumflex(recording["wordform"])
+        if "moswacihk" in speech_db_eq:
+            entry = macron_to_circumflex(recording["wordform"])
+        else:
+            entry = recording["wordform"]
         matched_recordings[entry] = {}
         matched_recordings[entry]["recording_url"] = recording["recording_url"]
         matched_recordings[entry]["speaker"] = recording["speaker"]


### PR DESCRIPTION
## What's in this PR:
Gunáhà had an issue where audio wasn't showing up for seemingly random entries. As it turns out, I was converting all macrons to circumflexes, which meant none of the words were matched to a recording and there were no recordings to display. This worked sometimes because not all words had macrons in them. I needed to convert macrons to circumflexes for mōswacīhk, so now the code does just that for mōswacīhk only.